### PR TITLE
Move pym.js to the CDN version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Copyright 2014 INN.  All rights reserved.  No part of these materials may be reproduced, modified, stored in a retrieval system, or retransmitted, in any form or by any means, electronic, mechanical or otherwise, without prior written permission from INN.
 
-(Want to use this code? Send an email to nerds@investigativenewsnetwork.org!)
+(Want to use this code? Send an email to labs@inn.org!)
 
+This project was last updated in 2014; it is **NO LONGER MAINTAINED**. This note added in February 2018 when the project was updated to use the CDN version of Pym.js in response to [a Pym.js security vulnerability](blog.apps.npr.org/2018/02/15/pym-security-vulnerability.html).
 
 power-players
 ========================
@@ -91,6 +92,13 @@ fab update
 ```
 
 **Problems installing requirements?** You may need to run the pip command as ``ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future pip install -r requirements.txt`` to work around an issue with OSX.
+
+**Problems running fab update?**
+
+If you receive a `openpyxl.shared.exc.InvalidFileException: [Errno 2] No such file or directory: 'data/copy.xlsx'`, you'll need to download https://docs.google.com/spreadsheets/d/16VQA9d30-1xQIrtY17NMYj5tLCSdY63Bsd2IuqFJlJo/edit#gid=1803763652 and save it in this folder at `data/copy.xlsx`. Don't commit the file to git, please and thank you.
+
+If you receive `KeyError: "Error! You're missing some variables. You need to export APPS_GOOGLE_EMAIL and APPS_GOOGLE_PASS."`, just don't run `fab text` commands, or any command that runs `fab text` or `fab text.update`. Download the required `.xlsx` file through the above route.
+
 
 Hide project secrets
 --------------------

--- a/app_config.py
+++ b/app_config.py
@@ -107,7 +107,7 @@ SHARE_URL = 'http://%s/%s/' % (PRODUCTION_S3_BUCKETS[0], PROJECT_SLUG)
 SERVICES
 """
 GOOGLE_ANALYTICS = {
-    'ACCOUNT_ID': 'UA-17578670-10', # apps.investigativenewsnetwork.org
+    'ACCOUNT_ID': 'UA-17578670-10', # apps.inn.org
     'DOMAIN': PRODUCTION_S3_BUCKETS[0],
     'TOPICS': '' # e.g. '[1014,3,1003,1002,1001]'
 }

--- a/app_config.py
+++ b/app_config.py
@@ -35,21 +35,21 @@ DEPLOYMENT
 """
 PRODUCTION_S3_BUCKETS = [
     {
-        'bucket_name': 'apps.investigativenewsnetwork.org',
-        'region': 'us-west-2'
+        'bucket_name': 'apps.inn.org',
+        'region': 'us-east-1'
     }
 ]
 
 STAGING_S3_BUCKETS = [
     {
-        'bucket_name': 'stage-apps.investigativenewsnetwork.org',
-        'region': 'us-west-2'
+        'bucket_name': 'stage-apps.inn.org',
+        'region': 'us-east-1'
     }
 ]
 
 ASSETS_S3_BUCKET = {
-    'bucket_name': 'assets.apps.investigativenewsnetwork.org',
-    'region': 'us-west-2'
+    'bucket_name': 'assets.apps.inn.org',
+    'region': 'us-east-1'
 }
 
 PRODUCTION_SERVERS = ['']

--- a/fabfile/assets.py
+++ b/fabfile/assets.py
@@ -227,7 +227,9 @@ def _assets_download(s3_key, local_path):
     if not (os.path.exists(dirname)):
         os.makedirs(dirname)
 
-    s3_key.get_contents_to_filename(local_path)
+    # this is necessary so we're not attempting to os.remove directories that might exist
+    if not (dirname == local_path.strip("/")):
+        s3_key.get_contents_to_filename(local_path)
 
 def _assets_upload(local_path, s3_key):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,11 @@ PyYAML==3.11
 Werkzeug==0.8.3
 awscli==1.2.10
 bcdoc==0.12.0
-boto==2.25.0
-botocore==0.31.0
+boto==2.48
 clan==0.1.3
 colorama==0.2.5
 copytext==0.1.4
-cssmin==0.1.4
+cssmin==0.2
 docutils==0.11
 facebook-sdk==0.4.0
 google-api-python-client==1.2

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -30,7 +30,7 @@
     {% block outer_content %}
     <nav role="navigation">
         <ul class="site-links">
-            <li class="inn-image"><a title="Investigative News Network" href="http://www.investigativenewsnetwork.org"><span>INN</span></a></li>
+            <li class="inn-image"><a title="Investigative News Network" href="http://inn.org"><span>INN</span></a></li>
         </ul>
         {% include '_social_links.html' %}
     </nav>
@@ -58,15 +58,15 @@
     <footer>
         <div class="primary">
             <ul>
-                <li class="inn-image"><a title="Investigative News Network" href="http://www.investigativenewsnetwork.org" data-action="Click Logo"><span>INN</span></a></li>
+                <li class="inn-image"><a title="Investigative News Network" href="http://inn.org" data-action="Click Logo"><span>INN</span></a></li>
             </ul>
         </div>
         <div class="secondary">
             <p>&copy;2014 INN</p>
             <ul>
-                <li id="footerContact"><a href="http://investigativenewsnetwork.org/contact/">Contact</a></li>
-                <li><a href="http://investigativenewsnetwork.org/about/legal/terms-of-service/">Terms of Service</a></li>
-                <li><a href="http://investigativenewsnetwork.org/about/legal/privacy-statement/">Privacy</a></li>
+                <li id="footerContact"><a href="http://inn.org/contact/">Contact</a></li>
+                <li><a href="http://inn.org/about/legal/terms-of-service/">Terms of Service</a></li>
+                <li><a href="http://inn.org/about/legal/privacy-statement/">Privacy</a></li>
             </ul>
         </div>
     </footer>

--- a/templates/_branding_link.html
+++ b/templates/_branding_link.html
@@ -1,1 +1,1 @@
-<div class="an-inn-newsapp"><a target="_parent" href="http://investigativenewsnetwork.org/">An <span class="inn-logo">INN</span> news application</a></div>
+<div class="an-inn-newsapp"><a target="_parent" href="http://inn.org/">An <span class="inn-logo">INN</span> news application</a></div>

--- a/templates/embed_player.html
+++ b/templates/embed_player.html
@@ -43,10 +43,10 @@
   {{ JS.push('js/app_config.js') }}
   {{ JS.push('js/console.js') }}
   {{ JS.push('js/templates.js') }}
-  {{ JS.push('assets/js/pym.js') }}
   {{ JS.push('js/app.js') }}
   {{ JS.push('js/analytics.js') }}
   {{ JS.render('js/embed-footer.min.js') }}
+  <script type="text/javascript" src="https://pym.nprapps.org/pym.v1.min.js"></script>
   <script type="text/javascript">
     var pymChild;
     $(document).ready(function() {

--- a/templates/embed_state.html
+++ b/templates/embed_state.html
@@ -56,10 +56,10 @@
   {{ JS.push('js/app_config.js') }}
   {{ JS.push('js/console.js') }}
   {{ JS.push('js/templates.js') }}
-  {{ JS.push('assets/js/pym.js') }}
   {{ JS.push('js/app.js') }}
   {{ JS.push('js/analytics.js') }}
   {{ JS.render('js/embed-footer.min.js') }}
+  <script type="text/javascript" src="https://pym.nprapps.org/pym.v1.min.js"></script>
   <script type="text/javascript">
     var pymChild = new pym.Child();
   </script>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -85,7 +85,7 @@ var embedModal = function(e, type) {
         name = target.data(type + '-name'),
         deployment_target = APP_CONFIG.DEPLOYMENT_TARGET,
         embed_url = APP_CONFIG.S3_BASE_URL + '/embed/' + type + '/' + slug + '/',
-        pym_url = APP_CONFIG.S3_BASE_URL + '/assets/js/pym.js',
+        pym_url = 'https://pym.nprapps.org/pym.v1.min.js',
         player_container = target.closest('.' + type);
 
     var modal = JST.embedModal({


### PR DESCRIPTION
## Changes

- notes that this project is not maintained anymore
- adds some improved docs to make it easier to set this up in the future
- updates bucket names to their correct post-INN-rebranding URLs
- fixes a bug when running `fab assets.sync`
- updates `boto` and `cssmin` dependencies
- removes references to a local version of Pym.js and instead refers to the CDN-hosted version

## Why

https://blog.apps.npr.org/2018/02/15/pym-security-vulnerability.html